### PR TITLE
Fix notification-listener dependency link

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -28,7 +28,7 @@
     <plugin name="io.gvox.plugin.phonecalltrap" spec="^0.1.2" />
     <plugin name="cordova-plugin-broadcaster" spec="^3.1.1" />
     <plugin name="cordova-plugin-background-mode" spec="^0.7.2" />
-    <plugin name="net.coconauts.notification-listener" spec="/Users/sehrbastian/Entwicklung/NotificationListenerService/NotificationListener-cordova" />
+    <plugin name="net.coconauts.notification-listener" spec="https://github.com/phalix/NotificationListener-cordova" />
     <preference name="AndroidLaunchMode" value="singleTask" />
     <plugin name="cordova-plugin-local-notification" spec="^0.9.0-beta.2" />
     <engine name="browser" spec="^5.0.3" />

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-serve": "^3.0.0",
     "io.gvox.plugin.phonecalltrap": "^0.1.2",
-    "net.coconauts.notification-listener": "file:////Users/ramod/work/play/NotificationListener-cordova-master",
+    "net.coconauts.notification-listener": "git+https://github.com/coconauts/NotificationListener-cordova.git",
     "shelljs": "^0.8.3"
   },
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cordova-plugin-whitelist": "^1.3.3",
     "cordova-serve": "^3.0.0",
     "io.gvox.plugin.phonecalltrap": "^0.1.2",
-    "net.coconauts.notification-listener": "git+https://github.com/coconauts/NotificationListener-cordova.git",
+    "net.coconauts.notification-listener": "git+https://github.com/phalix/NotificationListener-cordova.git",
     "shelljs": "^0.8.3"
   },
   "cordova": {


### PR DESCRIPTION
I was not able to compile without changing the below link. I'm not sure what the difference is between the local version and the one on github. If there are any differences, it would be helpful uploading that dependency to github so others can benefit from it as well :)

Edit: I think I found your repo and have updated the code to reference it.